### PR TITLE
Fixes bug with notes cache

### DIFF
--- a/python/datamodel/generate/stub.py
+++ b/python/datamodel/generate/stub.py
@@ -263,6 +263,8 @@ class BaseStub(abc.ABC):
         self._update_cache_changelog()
 
         # literal-ize any cache notes (see notes on literal in filetypes/par.py)
+        if 'notes' not in self._cache:
+            self._cache['notes'] = None
         self._cache['notes'] = literal(self._cache['notes'])
 
     def _check_release_in_cache(self, content: dict) -> dict:


### PR DESCRIPTION
This PR closes #81 where datamodel's generated before the `notes` was added crashed.   It now adds a default `notes=None` to the datamodel.  