### PR TITLE
Add missing dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,8 @@ install_requires =
 	pydantic>=2.0
 	orjson>=3.5.3
 	fuzzy_types>=0.1.3
+	cloup>=3.0.5
+	configobj>=5.0.8
 
 scripts =
 	# vesitigial scripts - keeping for backwards compatibility


### PR DESCRIPTION
Necessary dependencies to run, at least, `datamodel generate`.